### PR TITLE
add toBeValidDotAndMatchSnapshot Matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you don't have it installed, install it here[here](https://graphviz.gitlab.io
 
 ## Usage
 
-### toBeValidDot
+### `toBeValidDot`
 
 ```typescript
 describe('toBeValidDot test', () => {
@@ -70,7 +70,17 @@ describe('toBeValidDot test', () => {
     expect(dot).not.toBeValidDot();
   });
 });
+```
 
+### `toBeValidDotAndMatchSnapshot`
+
+```typescript
+describe('toBeValidDotAndMatchSnapshot test', () => {
+  test('matcher works', () => {
+    const dot = 'digraph g { a -> b; }';
+    expect(dot).toBeValidDotAndMatchSnapshot();
+  });
+});
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@types/jest": "^24.0.22"
+    "@types/jest": "^24.0.22",
+    "jest": "^24.9.0",
+    "jest-snapshot": "^24.9.0"
   },
   "devDependencies": {
     "@types/node": "^12.12.7",
-    "jest": "^24.9.0",
     "prettier": "^1.19.1",
     "ts-jest": "^24.1.0",
     "tslint": "^5.20.1",

--- a/src/__test__/__snapshots__/to-be-valid-dot-and-match-snapshot.spec.ts.snap
+++ b/src/__test__/__snapshots__/to-be-valid-dot-and-match-snapshot.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toBeValidDotAndMatchSnapshot test matcher works 1`] = `"digraph g { a -> b; }"`;

--- a/src/__test__/to-be-valid-dot-and-match-snapshot.spec.ts
+++ b/src/__test__/to-be-valid-dot-and-match-snapshot.spec.ts
@@ -1,0 +1,8 @@
+import '../to-be-valid-dot-and-match-snapshot';
+
+describe('toBeValidDotAndMatchSnapshot test', () => {
+  test('matcher works', () => {
+    const dot = 'digraph g { a -> b; }';
+    expect(dot).toBeValidDotAndMatchSnapshot();
+  });
+});

--- a/src/__test__/to-be-valid-dot.spec.ts
+++ b/src/__test__/to-be-valid-dot.spec.ts
@@ -1,12 +1,12 @@
 import '../to-be-valid-dot';
 
 describe('toBeValidDot test', () => {
-  it('matcher works', () => {
+  test('matcher works', () => {
     const dot = 'digraph g { a -> b; }';
     expect(dot).toBeValidDot();
   });
 
-  it('invalid dot', () => {
+  test('invalid dot', () => {
     const dot = 'invalid';
     expect(dot).not.toBeValidDot();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { toBeValidDotMatcher } from './to-be-valid-dot';
+export { toBeValidDotAndMatchSnapshotMatcher } from './to-be-valid-dot-and-match-snapshot';

--- a/src/lib/__test__/is-valid-dot.spec.ts
+++ b/src/lib/__test__/is-valid-dot.spec.ts
@@ -1,13 +1,13 @@
 import { isValidDot } from '../is-valid-dot';
 describe('isValidDot test', () => {
-  it('matcher works', () => {
+  test('matcher works', () => {
     const dot = 'digraph g { a -> b; }';
     const result = isValidDot(dot);
     expect(result.pass).toBe(true);
     expect(result.message()).toBe('expected value to be valid dot format.');
   });
 
-  it('invalid dot', () => {
+  test('invalid dot', () => {
     const dot = 'invalid';
     const result = isValidDot(dot);
     expect(result.pass).toBe(false);

--- a/src/to-be-valid-dot-and-match-snapshot.ts
+++ b/src/to-be-valid-dot-and-match-snapshot.ts
@@ -1,0 +1,21 @@
+import { toMatchSnapshot } from 'jest-snapshot';
+import { isValidDot } from './lib/is-valid-dot';
+
+declare global {
+  namespace jest {
+    // tslint:disable-next-line: interface-name
+    interface Expect {
+      toBeValidDotAndMatchSnapshot<T>(): JestMatchers<T>;
+    }
+    // tslint:disable-next-line: interface-name
+    interface Matchers<R, T> {
+      toBeValidDotAndMatchSnapshot(): R;
+    }
+  }
+}
+
+export function toBeValidDotAndMatchSnapshotMatcher(this: any, dot: string): jest.CustomMatcherResult {
+  return isValidDot(dot) && toMatchSnapshot.call(this, dot);
+}
+
+expect.extend({ toBeValidDotAndMatchSnapshot: toBeValidDotAndMatchSnapshotMatcher });


### PR DESCRIPTION
```typescript
describe('New API, toBeValidDotAndMatchSnapshot', () => {
  it('to be valid dot and match snapshot ', () => {
    const dot = 'digraph g { a -> b; }';
    expect(dot).toBeValidDotAndMatchSnapshot();
  });
});
```
